### PR TITLE
Improve conversion from bytes to pillow images

### DIFF
--- a/stable_diffusion_cpp/stable_diffusion.py
+++ b/stable_diffusion_cpp/stable_diffusion.py
@@ -1813,27 +1813,19 @@ class StableDiffusion:
     # -------------------------------------------
 
     def _bytes_to_image(self, byte_data: bytes, width: int, height: int, channel: int = 3) -> Image.Image:
-        """Convert a byte array to a PIL Image."""
-        # Initialize the image with RGBA mode
-        image = Image.new("RGBA", (width, height))
+        pixel_length = width * height * channel
+        data = byte_data[:pixel_length].ljust(pixel_length, b'\x00')
 
-        for y in range(height):
-            for x in range(width):
-                idx = (y * width + x) * channel
-                # Dynamically create the color tuple
-                color = tuple(byte_data[idx + i] if idx + i < len(byte_data) else 0 for i in range(channel))
-                if channel == 1:  # Grayscale
-                    color = (color[0],) * 3 + (255,)  # Convert to (R, G, B, A)
-                elif channel == 3:  # RGB
-                    color = color + (255,)  # Add alpha channel
-                elif channel == 4:  # RGBA
-                    pass  # Use color as is
-                else:
-                    raise ValueError(f"Unsupported channel value: '{channel}'")
-                # Set the pixel
-                image.putpixel((x, y), color)
-
-        return image
+        if channel == 3:
+            return Image.frombytes("RGB", (width, height), data).convert("RGBA")
+        
+        if channel == 4:
+            return Image.frombytes("RGBA", (width, height), data)
+        
+        if channel == 1:
+            return Image.frombytes("L", (width, height), data).convert("RGBA")
+        
+        raise ValueError(f"Unsupported channel value: '{channel}'")
 
     # -------------------------------------------
     # Clean Path

--- a/stable_diffusion_cpp/stable_diffusion.py
+++ b/stable_diffusion_cpp/stable_diffusion.py
@@ -1813,6 +1813,8 @@ class StableDiffusion:
     # -------------------------------------------
 
     def _bytes_to_image(self, byte_data: bytes, width: int, height: int, channel: int = 3) -> Image.Image:
+        """Convert a byte array to a PIL Image."""
+
         pixel_length = width * height * channel
         data = byte_data[:pixel_length].ljust(pixel_length, b'\x00')
 


### PR DESCRIPTION
When converting bytes to images (Pillow), it seems that looping over all pixels and calling `putpixel` multiple times takes longer than using the native `Image.frombytes` function.

While the old function can take several seconds, the new one takes only a few milliseconds.

However, perhaps there was a specific reason for writing this `_bytes_to_image` function this way rather than using the native `Image.frombytes` function? In that case, please let me know.